### PR TITLE
Catch 'out-of-range' exception by reference

### DIFF
--- a/test/neighbortest.cc
+++ b/test/neighbortest.cc
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
             fprintf(stderr, "neighbortest: expected range error exception from check_messages\n");
             r = 2;
         }
-        catch (std::out_of_range) {
+        catch (std::out_of_range&) {
         }
 
         check_messages1(ann, bob, { 1, 2, 3 });

--- a/tools/mkgraph.cc
+++ b/tools/mkgraph.cc
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
         print_exception(e, stderr);
         return 1;
     }
-    catch (std::runtime_error e) {
+    catch (std::runtime_error& e) {
         fprintf(stderr, "[Exception] %s\n", e.what());
         return 1;
     };


### PR DESCRIPTION
GCC 8.1 emits a warning when polymorphic exception types are catched by
value. The fix is to catch the those exceptions by reference.

Signed-off-by: Mahircan Guel <mahircan.guel@intel.com>